### PR TITLE
Add CONTRIBUTORS file including DNA sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ This project is hereby licensed under the [WTFPL](http://www.wtfpl.net/txt/copyi
 
 ## Contribution Policy
 Due to various compliance requirements, you are now required to submit a DNA
-test in your first pull request to this repository. If it is found out that you
-are more than 50% Russian by blood, your pull request will be rejected.
-Additionally, if it is found out that you are more than 10% Russian by blood,
-you must provide one of the following or your pull request will be rejected:
+test in the CONTRIBUTORS file as part of your first pull request to this
+repository. If it is found out that you are more than 50% Russian by blood,
+your pull request will be rejected. Additionally, if it is found out that you
+are more than 10% Russian by blood, you must provide one of the following or
+your pull request will be rejected:
   - A photo of a valid ID or equivalent document proving that you are not
     citizen of the Russian Federation;
   - A photo of a valid residence permit or equivalent document issued by a state


### PR DESCRIPTION
The README was previously unclear on where to submit your DNA test, so I figured I'd clarify that it should go in CONTRIBUTORS, where it can be publicly audited.

As this is my first pull request, I have added my genome to the file, which should also serve as an example for future contributors.